### PR TITLE
Spec updates

### DIFF
--- a/schema/view.schema.json
+++ b/schema/view.schema.json
@@ -259,8 +259,8 @@
                             "description": "Thickness of the boundary masks. Only used if showAsBoundaries is true.",
                             "type": "number"
                         },
-                        "glasbeyRandomSeed": {
-                            "description": "Random seed for the glasbey lut to reproduce the exact colors of the view. (Optional)",
+                        "randomColorSeed": {
+                            "description": "Random seed for the random color lut (e.g. glasbey) to reproduce the exact colors of the view. (Optional)",
                             "type": "number"
                         }
                     },
@@ -337,8 +337,8 @@
                             "description": "Thickness of the boundary masks. Only used if showAsBoundaries is true.",
                             "type": "number"
                         },
-                        "glasbeyRandomSeed": {
-                            "description": "Random seed for the glasbey lut to reproduce the exact colors of the view. (Optional)",
+                        "randomColorSeed": {
+                            "description": "Random seed for the random color lut (e.g. glasbey) to reproduce the exact colors of the view. (Optional)",
                             "type": "number"
                         }
                     },

--- a/schema/view.schema.json
+++ b/schema/view.schema.json
@@ -283,7 +283,7 @@
                             "$ref": "#/definitions/name"
                         },
                         "sources": {
-                            "description": "Map of source_annotation_ids (first table column) to source per location.",
+                            "description": "Map of region_ids (first table column) to source per location.",
                             "$ref": "#/definitions/mapOfSources",
                             "minProperties": 1
                         },
@@ -297,7 +297,7 @@
                             "$ref": "#/definitions/lut"
                         },
                         "colorByColumn": {
-                            "description": "Name of table column that is used for coloring. By default the 'source_annotation_id' column is used.",
+                            "description": "Name of table column that is used for coloring. By default the 'region_id' column is used.",
                             "$ref": "#/definitions/name"
                         },
                         "opacity": {
@@ -306,8 +306,8 @@
                         "valueLimits": {
                             "$ref": "#/definitions/valueLimits"
                         },
-                        "selectedAnnotationIds": {
-                            "description": "List of selected source annotation ids, each of the form timePoint;annotationId",
+                        "selectedRegionIds": {
+                            "description": "List of selected source region ids, each of the form timePoint;regionId",
                             "type": "array",
                             "items": {
                                 "type": "string",

--- a/schema/view.schema.json
+++ b/schema/view.schema.json
@@ -272,11 +272,11 @@
             "additionalProperties": false
         },
 
-        "sourceAnnotationDisplay": {
+        "regionDisplay": {
             "description": "Viewer state for a spatial arrangement of sources, e.g. via grid transform, with an associated table.",
             "type": "object",
             "properties": {
-                "sourceAnnotationDisplay": {
+                "regionDisplay": {
                     "type": "object",
                     "properties": {
                         "name": {
@@ -346,7 +346,7 @@
                     "additionalProperties": false
                 }
             },
-            "required": ["sourceAnnotationDisplay"],
+            "required": ["regionDisplay"],
             "additionalProperties": false
         },
 
@@ -687,7 +687,7 @@
             "items": {"anyOf": [
                 {"$ref": "#/definitions/imageDisplay"},
                 {"$ref": "#/definitions/segmentationDisplay"},
-                {"$ref": "#/definitions/sourceAnnotationDisplay"}
+                {"$ref": "#/definitions/regionDisplay"}
             ]}
         },
         "sourceTransforms": {

--- a/schema/view.schema.json
+++ b/schema/view.schema.json
@@ -532,7 +532,7 @@
                         "positions": {
                             "$ref": "#/definitions/positions"
                         },
-                        "sources": {
+                        "nestedSources": {
                             "description": "The sources for the grid. Map of grid posititions to sources per position.",
                             "$ref": "#/definitions/nestedListOfSources",
                             "minItems": 2

--- a/specs/mobie_spec.md
+++ b/specs/mobie_spec.md
@@ -264,16 +264,16 @@ A `view` stores all metadata necessary to fully reproduce a MoBIE viewer state.
 
 Views can optionally contain source annotations, which are specified via a `sourceAnnotationDisplay` (see schema description below). Source annotations contain a table, which has rows that are associated with the sources in this view and can be used to navigate to the sources (by clicking on the row) and store additional source level annotations.
 Source annotation tables should be stored as tab separated values, but may also be comma separated.
-They must contain the column `annotation_id`, which is used for navigation in the viewer, and must contain at least one more column.
-The values in the `annotation_id` must be strings and must correspond to the keys of the `sources` field in the `sourceAnnotationDisplay`.
+They must contain the column `region_id`, which is used for navigation in the viewer, and must contain at least one more column.
+The values in the `region_id` must be strings and must correspond to the keys of the `sources` field in the `sourceAnnotationDisplay`.
 A primary application of source annotations are tables for views containing a `grid` transform (see schema description below).
 
-In this case the `annotation_id` column corresponds to the flat grid position, which is computed from the 2d grid position according to the row-major indexing convention.
+In this case the `region_id` column corresponds to the flat grid position, which is computed from the 2d grid position according to the row-major indexing convention.
 The mapping of grid positions to sources is defined in the `sources` field.
 
 See an example grid view table for 4 grid positions that also gives the presence of different organelles for each position.
 ```tsv
-annotation_id    mitochondria    vesicles    golgi   er
+region_id   mitochondria    vesicles    golgi   er
 source1   1   0   1   0
 source2   1   0   1   1
 source3   0   0   0   1

--- a/specs/template_view.md
+++ b/specs/template_view.md
@@ -6,16 +6,16 @@ A `view` stores all metadata necessary to fully reproduce a MoBIE viewer state.
 
 Views can optionally contain source annotations, which are specified via a `sourceAnnotationDisplay` (see schema description below). Source annotations contain a table, which has rows that are associated with the sources in this view and can be used to navigate to the sources (by clicking on the row) and store additional source level annotations.
 Source annotation tables should be stored as tab separated values, but may also be comma separated.
-They must contain the column `annotation_id`, which is used for navigation in the viewer, and must contain at least one more column.
-The values in the `annotation_id` must be strings and must correspond to the keys of the `sources` field in the `sourceAnnotationDisplay`.
+They must contain the column `region_id`, which is used for navigation in the viewer, and must contain at least one more column.
+The values in the `region_id` must be strings and must correspond to the keys of the `sources` field in the `sourceAnnotationDisplay`.
 A primary application of source annotations are tables for views containing a `grid` transform (see schema description below).
 
-In this case the `annotation_id` column corresponds to the flat grid position, which is computed from the 2d grid position according to the row-major indexing convention.
+In this case the `region_id` column corresponds to the flat grid position, which is computed from the 2d grid position according to the row-major indexing convention.
 The mapping of grid positions to sources is defined in the `sources` field.
 
 See an example grid view table for 4 grid positions that also gives the presence of different organelles for each position.
 ```tsv
-annotation_id    mitochondria    vesicles    golgi   er
+region_id    mitochondria    vesicles    golgi   er
 source1   1   0   1   0
 source2   1   0   1   1
 source3   0   0   0   1


### PR DESCRIPTION
Addressing the following things:

- [x]  Renaming fields, see https://github.com/mobie/mobie-viewer-fiji/pull/703
  - the only changes necessary were `sourceAnnotationDisplay->regionDisplay`, `selctedAnnotationIds->selectedRegionIds`
  - the rest of the renaming discussed in the PR was updated in the spec already (e.g. `imageDisplay` instead of `imageSourceDisplay`)
- [x] Rename `annotation_id` column to -> `region_id`, see https://github.com/mobie/mobie-viewer-fiji/issues/681
- [x] Find different filed names for different types of source lists, see https://github.com/mobie/mobie-viewer-fiji/issues/620