### PR TITLE
Add optional channel property to ome.zarr image sources.

### DIFF
--- a/schema/source.schema.json
+++ b/schema/source.schema.json
@@ -53,6 +53,10 @@
                         "relativePath": {
                             "type": "string",
                             "description": "The file path to the xml storing the bdv metadata, relative to the dataset root location."
+                        },
+                        "channel": {
+                            "type": "integer",
+                            "description": "The channel to select from the ome.zarr data."
                         }
                     },
                     "required": ["relativePath"],
@@ -65,6 +69,10 @@
                         "relativePath": {
                             "type": "string",
                             "description": "The file path to the xml storing the bdv metadata, relative to the dataset root location."
+                        },
+                        "channel": {
+                            "type": "integer",
+                            "description": "The channel to select from the ome.zarr data."
                         }
                     },
                     "required": ["relativePath"],


### PR DESCRIPTION
Updates the source.schema.json such that the following call in mobie-utils-python works:
```
add_source_to_dataset(join(mobie_project_folder, dataset_name), "image", "C05", file_format="ome.zarr", 
                     image_metadata_path=join("/home/tibuch/Data/MolecularDevices/Test-set/zarr-files/MIP-4P-4sub.zarr/C/5/0/"),
                     channel=0)
```

Otherwise I get an error with channel not being allowed by the schema.