### PR TITLE
Update view.schema.json

### DIFF
--- a/schema/view.schema.json
+++ b/schema/view.schema.json
@@ -685,6 +685,14 @@
                             },
                             "minItems": 1
                         },
+                        "sourceNamesAfterTransform": {
+                            "description": "Names of the sources after transformation. If given, must have the same number of elements as `sources`.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/name"
+                            },
+                            "minItems": 1
+                        },
                         "name": {
                             "description": "Name of this transformation",
                             "$ref": "#/definitions/name"


### PR DESCRIPTION
This field was missing and it's crucial for showing multiple timepoints in one view.

Do we need it for the other transform types (grids) as well?