### PR TITLE
Update description in view.schema.json

### DIFF
--- a/schema/view.schema.json
+++ b/schema/view.schema.json
@@ -630,7 +630,7 @@
                     "description": "A grid view of multiple sources that creates an new merged source. Only valid if all sources have the same size (both in pixels and physical space).",
                     "properties": {
                         "sources": {
-                            "description": "The sources this transformation is applied to. After transformation all sources will get the name <sourceName>_<mergedGridSourceName>. <sourceName> still refers to the source befor transformation (useful e.g. for specifying a metadataSource)",
+                            "description": "The sources this transformation is applied to. After transformation all sources will get the name `<sourceName>_<mergedGridSourceName>`. `<sourceName>` still refers to the source befor transformation (useful e.g. for specifying a metadataSource)",
                             "type": "array",
                             "items": {
                                 "$ref": "#/definitions/name"


### PR DESCRIPTION
Fix formatting of html-like tags in description string.

I'm unsure how https://github.com/mobie/mobie.github.io/blob/master/specs/mobie_spec.md is generated from the content of the spec files like https://github.com/mobie/mobie.github.io/blob/master/schema/view.schema.json, but on https://mobie.github.io/specs/mobie_spec.html these fields are currently interpreted as HTML tags and therefore rendered wrongly.

I edited `view.schema.json` only, but the change will be required in the markdown file as well, I guess.
